### PR TITLE
fix two dashboard bugs

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -41,7 +41,9 @@ const styles = {
 function App() {
   return (
     <ApolloProvider client={client}>
-      <Router>
+      <Router
+      basename='/'
+      >
         <Nav />
         <Routes>
           <Route exact path="/" element={<Feed/>} />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -40,20 +40,18 @@ html,body
     background-position: center;
     background-image: url("./assets/images/page.png");
     background-size: cover;
-    padding: "0px 30px 0px 60px";
+    padding: 0px 30px 0px 60px;
+    
     filter: drop-shadow(20px 15px 10px rgba(1,1,1,.5));
 }
 
-.drop-zone {
-    margin-left: 10.5%;
-}
 
 .sticker-shadow {
     filter: drop-shadow(2px 2px 1px rgba(1,1,1,.2));
 }
 
 .nav-padding {
-    padding-top: 10%;
+    padding-top: 12%;
 }
 
 #notebook-title {
@@ -68,7 +66,7 @@ html,body
         width: 350px;
         height: 418px;
         background-image: url("./assets/images/page-small.png");
-        padding: "0px 30px 0px 30px";
+        padding: 0px 30px 0px 30px;
     }
     
     .login {

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -63,8 +63,8 @@ const Dashboard = () => {
         if (goal.type === 'Personal') {goalType = artCross};
 
         // sets smaller coordinates for small page
-        let x = goal.x;
-        let y = goal.y;
+        let x = goal.x || 0;
+        let y = goal.y || 0;
         if (smallWidth) {
             x = Math.round(x*7/11);
             y = Math.round(y*7/11);
@@ -87,6 +87,18 @@ const Dashboard = () => {
     const handleSave = async (id, x, y, z) => {
         const token = Auth.loggedIn() ? Auth.getToken() : null;
         if (!token) { return false; }
+
+        // checks size of the document, if the page is small or large
+        let width = $(document).width();
+        if (width <= 600) {
+            smallWidth = true;
+        }
+
+        // sets smaller coordinates for small page
+        if (smallWidth) {
+            x = Math.round(x*11/7);
+            y = Math.round(y*11/7);
+        }
         
         try {
             const {data} = await updateSticker({
@@ -97,20 +109,8 @@ const Dashboard = () => {
         }
     }
 
-    // const handleSaveBtn = (event) => {
-    //     console.log("saved!")
-    //     goals.map((goal) => {
-    //         return(
-    //             handleSave(goal)
-    //         )
-    //     })
-    // }
-
     // call drag and drop functions for the class .drag and the id .drop
     useEffect(() => {
-        // get container height and width
-        const maxWidth = $(".page").width();
-        console.log(maxWidth);
 
         //drag the stickers, limit to the container and have the dragged sticker at the highest z-index in the stack
         $( ".drag" ).draggable({
@@ -124,10 +124,10 @@ const Dashboard = () => {
             stop: function(event, ui) {
                 setDraggingState(false);
                 let positionInfo = this.style.cssText.split(';');
-                let z = parseInt(positionInfo[3].split(' z-index: ')[1]);
-                let x = positionInfo[1].split(' left: ')[1];
+                let z = parseInt(positionInfo[3].split(' z-index: ')[1]) || 0;
+                let x = positionInfo[1].split(' left: ')[1] || 0;
                 x = parseInt(x, 10);
-                let y = positionInfo[2].split(' top: ')[1];
+                let y = positionInfo[2].split(' top: ')[1] || 0;
                 y = parseInt(y, 10);
                 console.log(x, " , ", y);
                 let id = $(this).data('goalid');

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -65,6 +65,7 @@ const Dashboard = () => {
         // sets smaller coordinates for small page
         let x = goal.x || 0;
         let y = goal.y || 0;
+        let z = goal.z || 0;
         if (smallWidth) {
             x = Math.round(x*7/11);
             y = Math.round(y*7/11);
@@ -78,7 +79,7 @@ const Dashboard = () => {
                 position: "absolute",
                 left: `${x}px`,
                 top: `${y}px`,
-                zIndex: `${goal.z}`,
+                zIndex: `${z}`,
             }}/>
         )
     }


### PR DESCRIPTION
1. New stickers now save positions on drag. A null value in x and y for new goals/stickers was initially causing the new positions not to save. Now x, y, z are set 0 if undefined, which allows updateSticker to work correctly.

2. Small view stickers move proportionally, and save corrected positions.  Because the page canvas is smaller on small viewport widths, the positional data must be multiplied by 7/11 when populating the stickers.  Similarly, the x and y values going to updateSticker must be multiplied by 11/7 on these small screens to save the correct coordinates. I just added that 11/7 correction.